### PR TITLE
修改最新签到域名

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,12 +28,12 @@ def push(content):
 
 # 会不定时更新域名，记得Sync fork
 
-login_url = 'https://ikuuu.one/auth/login'
-check_url = 'https://ikuuu.one/user/checkin'
-info_url = 'https://ikuuu.one/user/profile'
+login_url = 'https://ikuuu.de/auth/login'
+check_url = 'https://ikuuu.de/user/checkin'
+info_url = 'https://ikuuu.de/user/profile'
 
 header = {
-        'origin': 'https://ikuuu.one',
+        'origin': 'https://ikuuu.de',
         'user-agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
 }
 


### PR DESCRIPTION
This pull request updates the domain used for all API endpoint URLs and the HTTP request headers in `main.py`. The change ensures the script interacts with the correct server after a domain update.

- Domain update:
  * Changed all API endpoint URLs (`login_url`, `check_url`, and `info_url`) from `ikuuu.one` to `ikuuu.de` to reflect the new domain.
  * Updated the `origin` field in the `header` dictionary to match the new domain (`ikuuu.de`).